### PR TITLE
Add links.json info, spelling fixes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ Wml listens to changes in some folder (using [Watchman](https://facebook.github.
 
 Let's face it, sometimes symbolic links just aren't enough. Github has more than [10K issues](https://github.com/search?utf8=✓&q=support+for+symlinks&type=Issues) with the words "support for symlinks" in them. 
 
-Two examples I've encoutered so far were: React Native's packager [lack of support for them](https://github.com/facebook/react-native/issues/637) and Webpack's [inability to find linked modules dependencies](http://webpack.github.io/docs/troubleshooting.html#npm-linked-modules-doesn-t-find-their-dependencies) (working around this has issues of its own). A lot of people resolve to working directly from the node_modules folder in these cases, but *a.* if your package is required by two projects on which you are working simultaneously, you're screwed, and *b.* it just feels wrong.
+Two examples I've encountered so far were: React Native's packager [lack of support for them](https://github.com/facebook/react-native/issues/637) and Webpack's [inability to find linked modules dependencies](http://webpack.github.io/docs/troubleshooting.html#npm-linked-modules-doesn-t-find-their-dependencies) (working around this has issues of its own). A lot of people resolve to working directly from the node_modules folder in these cases, but *a.* if your package is required by two projects on which you are working simultaneously, you're screwed, and *b.* it just feels wrong.
 
 Wml makes use of Facebook's ultra-fast Watchman to watch for changes in your source folder and copy them (and only them) into your destination folder.
 
@@ -41,7 +41,9 @@ Adds a link.
 
 wml will not start listening to changes until you start it by running `wml start`.
 
-Eace link is given an unique id, you can see all links and their ids by running `wml list`.
+Each link is given an unique id, you can see all links and their ids by running `wml list`.
+Links are saved to `src/links.json` in your `wml` install directory, meaning that 
+your configuration is specific to that `wml` install.
 
 #### rm
 
@@ -63,7 +65,7 @@ It first copies all watched files from source to destination folder and then wai
 
 Lists all links.
 
-Shows link's id, state and source/destination folders.
+Shows each link's id, state and source/destination folders.
 
 #### enable
 


### PR DESCRIPTION
Document where the links file is located and that config is specific to the install of wml; rather than (necessarily) being global.

Feel free to reword for clarity, essentially I wanted to confirm how the config worked and where the config was so I could store it (eg my dotfiles repo).