### PR TITLE
Added new command once:  run all watchers once

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules
 src/links.json
+
+# IDE
+.idea/

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -7,11 +7,13 @@ var start = require('./start.js');
 var list = require('./list.js');
 var enable = require('./enable.js');
 var disable = require('./disable.js');
+var once = require('./once.js');
 
 require('yargs')
 	.usage('$0 <cmd> [args]')
 	.command(add)
 	.command(rm)
+	.command(once)
 	.command(start)
 	.command(list)
 	.command(enable)

--- a/src/cli/once.js
+++ b/src/cli/once.js
@@ -1,0 +1,119 @@
+'use strict';
+
+require('colors');
+
+var path = require('path');
+
+var capabilityCheck = require('../capabilityCheck.js');
+var watchProject = require('../watchProject.js');
+var getConfig = require('../getConfig.js');
+var subscribe = require('../subscribe.js');
+var watchman = require('fb-watchman');
+var links = require('../links.js');
+var copyHandler = require('../handlers/copy.js');
+
+exports.command = 'once';
+
+exports.describe = 'Updates all links once';
+
+exports.builder = {};
+
+function startWatcher(link) {
+	if (!link.enabled) {
+		return;
+	}
+
+	var client = new watchman.Client(),
+		relativePath,
+		watch;
+
+
+	capabilityCheck({
+		client: client
+	}).then(() => {
+
+		return watchProject({
+			client: client,
+			src: link.src
+		});
+
+	}).then((resp) => {
+
+		if ('warning' in resp) {
+			console.log('[watch-warning]'.yellow, resp.warning);
+		}
+
+		console.log('[watch]'.green, resp.watch);
+
+		relativePath = resp.relative_path;
+		watch = resp.watch;
+
+		return getConfig({
+			client: client,
+			src: link.src
+		});
+
+	}).then((resp) => {
+
+		console.log('[watch-config]'.green, resp.config);
+
+		return subscribe({
+			client: client,
+			watch: watch,
+			relativePath: relativePath,
+			src: link.src,
+			handler: copyHandler({
+				src: link.src,
+				dest: link.dest,
+				onExecuted : function()
+				{
+					stopWatcher(client, link.src, link.dest);
+				}
+			})
+		});
+
+	}).then(() => {
+		console.log('[subscribe]'.green, link.src);
+	}, (err) => {
+
+		client.end();
+
+		var error = err.watchmanResponse
+			? err.watchmanResponse.error
+			: err;
+
+		console.log('[error]'.red, error);
+
+		throw err;
+
+	}).done();
+
+	return client;
+}
+
+function stopWatcher(watcher, src, dest) {
+	watcher.end();
+	console.log('[end]'.green, src, '->' , dest);
+}
+
+function runLinksOnce()
+{
+	var i;
+
+	links.load();
+
+	if (Object.keys(links.data).length) {
+		// Create new watchers and change current watchers state
+		//
+		for (i in links.data) {
+			var link = links.data[i];
+			startWatcher(link);
+		}
+	}else {
+		console.log('[warning]'.yellow, 'no links set');
+	}
+}
+
+exports.handler = () => {
+	runLinksOnce();
+};

--- a/src/handlers/copy.js
+++ b/src/handlers/copy.js
@@ -20,5 +20,10 @@ module.exports = function (config) {
 				}
 			}
 		}
+
+		if (config.onExecuted)
+		{
+			config.onExecuted();
+		}
 	}
 }


### PR DESCRIPTION
Allowing one time synchronization is useful in several scenarios like when using CI to build multiple your product which is based on multiple-modules (repositories), or when you perform a build (`npm run build` or `npm run build:prod` and you want to make sure you are using the latest version of your dependent modules.

I used the `start.js` as the base workflow since it is quite similar to the workflow used to run the synchronization once. So most of the code should be familiar. I removed the part that listen to the `links.json` and added an interceptor to the `copyHandler` to end the subscription after one iteration per link.  